### PR TITLE
add set_heroku_vars_changed and run_heroku_config_if_settings_changed to...

### DIFF
--- a/roboconf.sh
+++ b/roboconf.sh
@@ -49,7 +49,10 @@ function roboconf-passenger {
   touch tmp/restart.txt
 }
 
-# "private" function called by run_heroku_config_if_settings_changed
+# "Private" function called by run_heroku_config_if_settings_changed.
+# Sets the heroku_vars_changed variable to true/false depending on whether
+# the Heroku environment variables in $HEROKU_CONSTANTS differ from what
+# is currently configured for the Heroku app.
 function detect_heroku_vars_changed {
   current_configs=$(heroku config --app "$app")
 


### PR DESCRIPTION
... roboconf.sh

This works on marketing release and prep-release. It will reconfigure Heroku settings (and restart Heroku to do so) only if the Heroku settings have changed. I would like to extend this to other scripts.

The basic idea is to replace:
  echo_cmd heroku config:set $HEROKU_CONFIG_ADD_CONSTANTS --app "$app"
with:
  curl -so .roboconf.sh https://raw.github.com/hedgeyedev/roboconf/master/roboconf.sh
  source .roboconf.sh
  run_heroku_config_if_settings_changed
