### PR TITLE
67518818 stop loading duplicate constants

### DIFF
--- a/roboconf.sh
+++ b/roboconf.sh
@@ -100,7 +100,7 @@ function detect_heroku_vars_changed {
     new_value="$( cut -d '=' -f 2- <<< $line )"
     new_value=`sed -E -e "s/(^'|'$)//g" <<< $new_value` # strip leading/trailing 's
     new_value=`sed -E -e "s/(^\"|\"$)//g" <<< $new_value` # strip leading/trailing "s
-    if [[ $new_key =~ 'HEROKU_CONFIG_ADD_CONSTANTS' || $new_key == \#* ]]; then
+    if [[ $new_key =~ 'HEROKU_CONFIG_ADD_CONSTANTS' || $new_key == \#* || $new_key == '' ]]; then
       continue   # ignore this script-only variable; it's not a Heroku config setting
     fi
     if [[ "$current_configs" == *"$new_key"* && "$current_configs" == *"$new_value"* ]]; then


### PR DESCRIPTION
prep-release was loading comments and blank lines into heroku config
fixed by skipping rows that are blank or start with #
