### PR TITLE
Bundler arg updates

### DIFF
--- a/roboconf.sh
+++ b/roboconf.sh
@@ -27,20 +27,20 @@ function roboconf-bundler1 {
   roboconf-check gem
   gem install bundler -v 1.17.3 --no-rdoc --no-ri
   # shellcheck disable=SC2086
-  roboconf-bundler-install $1
+  roboconf-bundler-install $*
 }
 
 function roboconf-bundler {
   roboconf-bundler-prepare
   # shellcheck disable=SC2086
-  roboconf-bundler-install $1
+  roboconf-bundler-install $*
 }
 
 function roboconf-bundler-dev {
   roboconf-bundler-prepare
   roboconf-bundler-without
   # shellcheck disable=SC2086
-  roboconf-bundler-install $1
+  roboconf-bundler-install $*
 }
 
 function roboconf-bundler-prepare {
@@ -51,7 +51,7 @@ function roboconf-bundler-prepare {
 
 function roboconf-bundler-install {
   # shellcheck disable=SC2086
-  bundle install $1
+  bundle install $*
 }
 
 function roboconf-bundler-without {

--- a/roboconf.sh
+++ b/roboconf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Begin loading roboconf functions..."
 


### PR DESCRIPTION
We shouldn't assume only one argument is being sent to bundler when installing. The shebang is better practice allowing for a user's bash to be located anywhere (e.g. when they have a homebrew version and a system default version).

These changes are used when building a local Docker container for CMS on M1 machines (yet to be PR'ed).